### PR TITLE
Fix TypeScript jest-dom matcher types in tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Fixed TypeScript errors for jest-dom matchers like toBeInTheDocument() by:

1. Removed test file exclusion from tsconfig.json:
   - Allows TypeScript to process test files and apply jest-dom types
   - Previously excluded files prevented type checking of test matchers

This ensures TypeScript recognizes jest-dom matchers in test files while
maintaining proper type safety for the testing environment.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
