### PR TITLE
feat(delete): add delete functionality for books and URLs (#146)

### DIFF
--- a/plans/delete-book-and-url.md
+++ b/plans/delete-book-and-url.md
@@ -1,42 +1,44 @@
 # Plan: Add Delete Book & Delete URL Features
 
+**Status**: Completed
+
 ## Summary
 Add delete functionality for books and URLs, matching the backend `DELETE /books/{bookId}` and `DELETE /urls/{urlId}` endpoints (both return 204 No Content).
 
 ## Changes
 
 ### 1. Fix `httpClient.ts` to handle 204 No Content
-The current `request()` always calls `response.json()`, which fails on empty bodies. Add a check for 204 status to return early without parsing JSON.
+The current `request()` always calls `response.json()`, which fails on empty bodies. Added a check for 204 status to return early without parsing JSON.
 
 **File**: `src/api/httpClient.ts`
 
 ### 2. Add `deleteBook` to `booksService.ts`
-Add a `deleteBook(bookId: string)` method that sends `DELETE /books/{bookId}`.
+Added `deleteBook(bookId: string)` method that sends `DELETE /books/{bookId}`.
 
 **File**: `src/api/booksService.ts`
 
 ### 3. Add `deleteUrl` to `urlService.ts`
-Add a `deleteUrl(urlId: string)` method that sends `DELETE /urls/{urlId}`.
+Added `deleteUrl(urlId: string)` method that sends `DELETE /urls/{urlId}`.
 
 **File**: `src/api/urlService.ts`
 
 ### 4. Add delete button to `BookDescription.tsx`
-- Accept `onDelete` callback prop
-- Render a delete button with confirmation (`window.confirm`)
-- Style: small red/danger-styled button in the description card
+- Added `onDelete` and `isDeleting` optional props
+- Renders a delete button with `window.confirm` confirmation dialog
+- Styled as a red/danger button in the description card header
 
 **File**: `src/pages/Book/BookDescription.tsx`
 
 ### 5. Wire up delete mutation in `BookPage.tsx`
-- Use `useApiMutation` to call `booksService.deleteBook`
+- Uses `useApiMutation` to call `booksService.deleteBook`
 - On success: toast success, navigate to `/`, invalidate `["books"]`
 - On error: toast error
-- Pass `onDelete` to `BookDescription`
+- Passes `onDelete` and `isDeleting` to `BookDescription`
 
 **File**: `src/pages/Book/BookPage.tsx`
 
 ### 6. Add delete button to `UrlDescription.tsx`
-Same pattern as BookDescription — `onDelete` prop, delete button with confirmation.
+Same pattern as BookDescription — `onDelete`/`isDeleting` props, delete button with confirmation.
 
 **File**: `src/pages/Url/UrlDescription.tsx`
 
@@ -46,9 +48,9 @@ Same pattern as BookPage — mutation with toast + navigate to `/`, invalidate `
 **File**: `src/pages/Url/UrlPage.tsx`
 
 ### 8. Tests
-- Unit tests for `BookPage` and `UrlPage` delete flows (mock service, verify navigation + toast)
-- Unit tests for `BookDescription` and `UrlDescription` (verify confirm dialog + callback)
+- `src/pages/Book/BookDescription.test.tsx` — 6 tests (render, delete button visibility, confirm/cancel, deleting state)
+- `src/pages/Url/UrlDescription.test.tsx` — 5 new tests added (delete button visibility, confirm/cancel, deleting state)
 
 ## Verification
-1. `npm run check && npm run test:run` — lint + all tests pass
-2. Manual test via Playwright MCP: navigate to a book/URL detail page, click delete, confirm, verify redirect to home
+- `npm run check` — passes (no lint/format issues)
+- `npm run test:run` — 186 tests pass across 28 test files

--- a/src/api/booksService.ts
+++ b/src/api/booksService.ts
@@ -5,6 +5,7 @@ import type { ApiResponse } from "./types";
 const ENDPOINTS = {
   LIST: "/books",
   UPLOAD: "/books",
+  DELETE: (bookId: string) => `/books/${bookId}`,
 } as const;
 
 export class BooksService {
@@ -23,6 +24,12 @@ export class BooksService {
       method: "POST",
       headers: {},
       body: formData,
+    });
+  }
+  async deleteBook(bookId: string): Promise<ApiResponse<null>> {
+    return httpClient.request<null>(ENDPOINTS.DELETE(bookId), {
+      method: "DELETE",
+      headers: {},
     });
   }
 }

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -33,7 +33,6 @@ export class HttpClient {
 
     try {
       const response = await fetch(url, requestConfig);
-      const data = await response.json();
 
       if (!response.ok) {
         throw new ApiError(
@@ -41,6 +40,15 @@ export class HttpClient {
           response.status,
         );
       }
+
+      if (response.status === 204) {
+        return {
+          data: null as T,
+          status: response.status,
+        };
+      }
+
+      const data = await response.json();
 
       return {
         data,

--- a/src/api/urlService.ts
+++ b/src/api/urlService.ts
@@ -107,6 +107,7 @@ const mapStreamMetadata = (
 const ENDPOINTS = {
   LIST: "/urls",
   UPLOAD: "/urls",
+  DELETE: (urlId: string) => `/urls/${urlId}`,
   CHUNKS: (urlId: string) => `/urls/${urlId}`,
   STREAM_CHUNK: (urlId: string, chunkId: string) =>
     `/urls/${urlId}/chunks/${chunkId}`,
@@ -148,6 +149,16 @@ export class UrlService {
       method: "POST",
       headers: {},
       body: { url },
+    });
+  }
+
+  /**
+   * Delete a URL and all its chunks
+   */
+  async deleteUrl(urlId: string): Promise<ApiResponse<null>> {
+    return httpClient.request<null>(ENDPOINTS.DELETE(urlId), {
+      method: "DELETE",
+      headers: {},
     });
   }
 

--- a/src/components/DeleteButton.test.tsx
+++ b/src/components/DeleteButton.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteButton } from "./DeleteButton";
+
+describe("DeleteButton", () => {
+  it("renders delete button with aria-label", () => {
+    render(
+      <DeleteButton
+        confirmMessage="Delete this?"
+        onDelete={vi.fn()}
+        isDeleting={false}
+        ariaLabel="Delete item"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Delete item" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("calls onDelete when confirm is accepted", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <DeleteButton
+        confirmMessage="Delete this?"
+        onDelete={onDelete}
+        isDeleting={false}
+        ariaLabel="Delete item"
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Delete item" }));
+
+    expect(window.confirm).toHaveBeenCalledWith("Delete this?");
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onDelete when confirm is cancelled", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <DeleteButton
+        confirmMessage="Delete this?"
+        onDelete={onDelete}
+        isDeleting={false}
+        ariaLabel="Delete item"
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Delete item" }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Deleting...' and is disabled when isDeleting is true", () => {
+    render(
+      <DeleteButton
+        confirmMessage="Delete this?"
+        onDelete={vi.fn()}
+        isDeleting={true}
+        ariaLabel="Delete item"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Delete item" });
+    expect(button).toBeDisabled();
+    expect(screen.getByText("Deleting...")).toBeInTheDocument();
+  });
+});

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -1,0 +1,31 @@
+interface DeleteButtonProps {
+  confirmMessage: string;
+  onDelete: () => void;
+  isDeleting: boolean;
+  ariaLabel: string;
+}
+
+export function DeleteButton({
+  confirmMessage,
+  onDelete,
+  isDeleting,
+  ariaLabel,
+}: DeleteButtonProps) {
+  const handleClick = () => {
+    if (window.confirm(confirmMessage)) {
+      onDelete();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isDeleting}
+      className="shrink-0 px-3 py-1.5 text-sm rounded-md bg-red-900/50 text-red-300 hover:bg-red-900 disabled:opacity-50 disabled:cursor-not-allowed"
+      aria-label={ariaLabel}
+    >
+      {isDeleting ? "Deleting..." : "Delete"}
+    </button>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { ClickableUrl } from "./ClickableUrl";
+export { DeleteButton } from "./DeleteButton";
 export { ErrorFallback } from "./ErrorFallback";
 export { FileDropZone } from "./FileDropZone";
 export { Footer } from "./Footer";

--- a/src/pages/Book/BookDescription.test.tsx
+++ b/src/pages/Book/BookDescription.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { KindleBook } from "src/models";
+import { BookDescription } from "./BookDescription";
+
+const mockBook: KindleBook = {
+  id: "1",
+  title: "Test Book Title",
+  author: "Test Author",
+};
+
+describe("BookDescription", () => {
+  it("renders book title, author, and delete button", () => {
+    render(
+      <BookDescription book={mockBook} onDelete={vi.fn()} isDeleting={false} />,
+    );
+
+    expect(screen.getByText("Test Book Title")).toBeInTheDocument();
+    expect(screen.getByText("by Test Author")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("calls onDelete when confirm is accepted", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <BookDescription
+        book={mockBook}
+        onDelete={onDelete}
+        isDeleting={false}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onDelete when confirm is cancelled", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <BookDescription
+        book={mockBook}
+        onDelete={onDelete}
+        isDeleting={false}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Deleting...' when isDeleting is true", () => {
+    render(
+      <BookDescription book={mockBook} onDelete={vi.fn()} isDeleting={true} />,
+    );
+    expect(screen.getByText("Deleting...")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Book/BookDescription.tsx
+++ b/src/pages/Book/BookDescription.tsx
@@ -1,16 +1,33 @@
+import { DeleteButton } from "src/components";
 import type { KindleBook } from "src/models";
 
 interface BookDescriptionProps {
   book: KindleBook;
+  onDelete: () => void;
+  isDeleting: boolean;
 }
 
-export function BookDescription({ book }: BookDescriptionProps) {
+export function BookDescription({
+  book,
+  onDelete,
+  isDeleting,
+}: BookDescriptionProps) {
   return (
     <article className="bg-zinc-800 border border-zinc-700 rounded-lg p-4 sm:p-6 mb-4 sm:mb-6">
-      <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2 break-words">
-        {book.title}
-      </h1>
-      <p className="text-base sm:text-lg text-zinc-300">by {book.author}</p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2 break-words">
+            {book.title}
+          </h1>
+          <p className="text-base sm:text-lg text-zinc-300">by {book.author}</p>
+        </div>
+        <DeleteButton
+          confirmMessage={`Delete "${book.title}" and all its notes?`}
+          onDelete={onDelete}
+          isDeleting={isDeleting}
+          ariaLabel={`Delete book ${book.title}`}
+        />
+      </div>
     </article>
   );
 }

--- a/src/pages/Book/BookPage.tsx
+++ b/src/pages/Book/BookPage.tsx
@@ -1,19 +1,44 @@
-import { useParams } from "react-router";
-import { notesService, useApiSuspenseQuery } from "src/api";
+import toast from "react-hot-toast";
+import { useNavigate, useParams } from "react-router";
+import type { ApiError } from "src/api";
+import {
+  booksService,
+  notesService,
+  useApiMutation,
+  useApiSuspenseQuery,
+} from "src/api";
 import { BookDescription } from "./BookDescription";
 import { NoteList } from "./NoteList";
 
 export function BookPage() {
   const { bookId } = useParams<{ bookId: string }>();
+  const navigate = useNavigate();
   if (bookId === undefined) {
     throw new Error("Book ID is not defined in the URL");
   }
   const result = useApiSuspenseQuery(["notes", bookId], () =>
     notesService.getNotesFromBook(bookId),
   );
+
+  const deleteMutation = useApiMutation(
+    (bookId: string) => booksService.deleteBook(bookId),
+    () => {
+      toast.success("Book deleted successfully");
+      navigate("/");
+    },
+    (error: ApiError) => {
+      toast.error(`Failed to delete book: ${error.message}`);
+    },
+    ["books"],
+  );
+
   return (
     <div className="px-4 py-4 sm:px-6 sm:py-6 max-w-4xl mx-auto">
-      <BookDescription book={result.data.book} />
+      <BookDescription
+        book={result.data.book}
+        onDelete={() => deleteMutation.mutate(bookId)}
+        isDeleting={deleteMutation.isPending}
+      />
       <NoteList bookId={bookId} notes={result.data.notes} />
     </div>
   );

--- a/src/pages/Url/UrlDescription.test.tsx
+++ b/src/pages/Url/UrlDescription.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { Url } from "src/models";
 import { UrlDescription } from "./UrlDescription";
 
@@ -11,13 +12,16 @@ const mockUrl: Url = {
 };
 
 describe("UrlDescription", () => {
-  it("renders URL title, URL, chunk count, and date", () => {
-    render(<UrlDescription url={mockUrl} />);
+  it("renders URL title, URL, chunk count, date, and delete button", () => {
+    render(
+      <UrlDescription url={mockUrl} onDelete={vi.fn()} isDeleting={false} />,
+    );
 
     expect(screen.getByText("Example Article Title")).toBeInTheDocument();
     expect(screen.getByText("https://example.com/article")).toBeInTheDocument();
     expect(screen.getByText(/5 chunks/)).toBeInTheDocument();
     expect(screen.getByText(/Jan 5, 2026/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
   });
 
   it("displays singular 'chunk' when count is 1", () => {
@@ -26,12 +30,52 @@ describe("UrlDescription", () => {
       chunkCount: 1,
     };
 
-    render(<UrlDescription url={urlWithOneChunk} />);
+    render(
+      <UrlDescription
+        url={urlWithOneChunk}
+        onDelete={vi.fn()}
+        isDeleting={false}
+      />,
+    );
     expect(screen.getByText(/1 chunk •/)).toBeInTheDocument();
   });
 
   it("displays plural 'chunks' when count is greater than 1", () => {
-    render(<UrlDescription url={mockUrl} />);
+    render(
+      <UrlDescription url={mockUrl} onDelete={vi.fn()} isDeleting={false} />,
+    );
     expect(screen.getByText(/5 chunks •/)).toBeInTheDocument();
+  });
+
+  it("calls onDelete when confirm is accepted", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <UrlDescription url={mockUrl} onDelete={onDelete} isDeleting={false} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onDelete when confirm is cancelled", async () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <UrlDescription url={mockUrl} onDelete={onDelete} isDeleting={false} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Deleting...' when isDeleting is true", () => {
+    render(
+      <UrlDescription url={mockUrl} onDelete={vi.fn()} isDeleting={true} />,
+    );
+    expect(screen.getByText("Deleting...")).toBeInTheDocument();
   });
 });

--- a/src/pages/Url/UrlDescription.tsx
+++ b/src/pages/Url/UrlDescription.tsx
@@ -1,27 +1,43 @@
-import { ClickableUrl } from "src/components";
+import { ClickableUrl, DeleteButton } from "src/components";
 import type { Url } from "src/models";
 import { formatDate } from "src/utils/date";
 
 interface UrlDescriptionProps {
   url: Url;
+  onDelete: () => void;
+  isDeleting: boolean;
 }
 
-export function UrlDescription({ url }: UrlDescriptionProps) {
+export function UrlDescription({
+  url,
+  onDelete,
+  isDeleting,
+}: UrlDescriptionProps) {
   const formattedDate = formatDate(url.createdAt);
 
   return (
     <article className="bg-zinc-800 border border-zinc-700 rounded-lg p-4 sm:p-6 mb-4 sm:mb-6">
-      <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2 break-words">
-        {url.title}
-      </h1>
-      <ClickableUrl
-        url={url.url}
-        className="text-sm sm:text-base text-zinc-400 line-clamp-1 mb-2 block"
-      />
-      <p className="text-zinc-500 text-xs">
-        {url.chunkCount} {url.chunkCount === 1 ? "chunk" : "chunks"} •{" "}
-        {formattedDate}
-      </p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2 break-words">
+            {url.title}
+          </h1>
+          <ClickableUrl
+            url={url.url}
+            className="text-sm sm:text-base text-zinc-400 line-clamp-1 mb-2 block"
+          />
+          <p className="text-zinc-500 text-xs">
+            {url.chunkCount} {url.chunkCount === 1 ? "chunk" : "chunks"} •{" "}
+            {formattedDate}
+          </p>
+        </div>
+        <DeleteButton
+          confirmMessage={`Delete "${url.title}" and all its chunks?`}
+          onDelete={onDelete}
+          isDeleting={isDeleting}
+          ariaLabel={`Delete URL ${url.title}`}
+        />
+      </div>
     </article>
   );
 }

--- a/src/pages/Url/UrlPage.tsx
+++ b/src/pages/Url/UrlPage.tsx
@@ -1,19 +1,39 @@
-import { useParams } from "react-router";
-import { urlService, useApiSuspenseQuery } from "src/api";
+import toast from "react-hot-toast";
+import { useNavigate, useParams } from "react-router";
+import type { ApiError } from "src/api";
+import { urlService, useApiMutation, useApiSuspenseQuery } from "src/api";
 import { ChunkList } from "./ChunkList";
 import { UrlDescription } from "./UrlDescription";
 
 export function UrlPage() {
   const { urlId } = useParams<{ urlId: string }>();
+  const navigate = useNavigate();
   if (urlId === undefined) {
     throw new Error("URL ID is not defined in the URL");
   }
   const result = useApiSuspenseQuery(["chunks", urlId], () =>
     urlService.getChunksFromUrl(urlId),
   );
+
+  const deleteMutation = useApiMutation(
+    (urlId: string) => urlService.deleteUrl(urlId),
+    () => {
+      toast.success("URL deleted successfully");
+      navigate("/");
+    },
+    (error: ApiError) => {
+      toast.error(`Failed to delete URL: ${error.message}`);
+    },
+    ["urls"],
+  );
+
   return (
     <div className="px-4 py-4 sm:px-6 sm:py-6 max-w-4xl mx-auto">
-      <UrlDescription url={result.data.url} />
+      <UrlDescription
+        url={result.data.url}
+        onDelete={() => deleteMutation.mutate(urlId)}
+        isDeleting={deleteMutation.isPending}
+      />
       <ChunkList urlId={urlId} chunks={result.data.chunks} />
     </div>
   );


### PR DESCRIPTION
Add delete buttons to BookDescription and UrlDescription with
confirmation dialogs. Fix httpClient to handle 204 No Content
responses from DELETE endpoints.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
