### PR TITLE
feat(random): support tweet_thread source type in random page

### DIFF
--- a/src/api/randomService.ts
+++ b/src/api/randomService.ts
@@ -20,7 +20,21 @@ interface UrlSourceApiResponse {
   created_at: string;
 }
 
-type SourceApiResponse = BookSourceApiResponse | UrlSourceApiResponse;
+interface TweetThreadSourceApiResponse {
+  id: string;
+  title: string;
+  type: "tweet_thread";
+  author_username: string;
+  author_display_name: string;
+  root_tweet_id: string;
+  tweet_count: number;
+  created_at: string;
+}
+
+type SourceApiResponse =
+  | BookSourceApiResponse
+  | UrlSourceApiResponse
+  | TweetThreadSourceApiResponse;
 
 interface NoteContentApiResponse {
   id: number;
@@ -38,7 +52,21 @@ interface UrlChunkContentApiResponse {
   created_at: string;
 }
 
-type ContentApiResponse = NoteContentApiResponse | UrlChunkContentApiResponse;
+interface TweetContentApiResponse {
+  id: string;
+  content_type: "tweet";
+  content: string;
+  author_username: string;
+  position_in_thread: number;
+  media_urls: string[];
+  tweeted_at: string;
+  created_at: string;
+}
+
+type ContentApiResponse =
+  | NoteContentApiResponse
+  | UrlChunkContentApiResponse
+  | TweetContentApiResponse;
 
 interface RandomContentApiResponse {
   source: SourceApiResponse;
@@ -57,6 +85,18 @@ const mapSource = (apiSource: SourceApiResponse): Source => {
       createdAt: apiSource.created_at,
     };
   }
+  if (apiSource.type === "tweet_thread") {
+    return {
+      id: apiSource.id,
+      title: apiSource.title,
+      type: "tweet_thread",
+      authorUsername: apiSource.author_username,
+      authorDisplayName: apiSource.author_display_name,
+      rootTweetId: apiSource.root_tweet_id,
+      tweetCount: apiSource.tweet_count,
+      createdAt: apiSource.created_at,
+    };
+  }
   return {
     id: String(apiSource.id),
     title: apiSource.title,
@@ -72,6 +112,18 @@ const mapContent = (apiContent: ContentApiResponse): Content => {
       id: String(apiContent.id),
       contentType: "note",
       content: apiContent.content,
+      createdAt: apiContent.created_at,
+    };
+  }
+  if (apiContent.content_type === "tweet") {
+    return {
+      id: String(apiContent.id),
+      contentType: "tweet",
+      content: apiContent.content,
+      authorUsername: apiContent.author_username,
+      positionInThread: apiContent.position_in_thread,
+      mediaUrls: apiContent.media_urls,
+      tweetedAt: apiContent.tweeted_at,
       createdAt: apiContent.created_at,
     };
   }

--- a/src/models/mappers.test.ts
+++ b/src/models/mappers.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapRelatedItemsToTweets,
+  mapTweetContentToTweet,
+  mapTweetThreadSourceToThread,
+} from "./mappers";
+import type { TweetContent, TweetThreadSource } from "./random";
+
+const mockTweetThreadSource: TweetThreadSource = {
+  id: "thread-1",
+  title: "Test Thread",
+  type: "tweet_thread",
+  authorUsername: "testuser",
+  authorDisplayName: "Test User",
+  rootTweetId: "tweet-root",
+  tweetCount: 3,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const mockTweetContent: TweetContent = {
+  id: "tweet-1",
+  contentType: "tweet",
+  content: "Hello world",
+  authorUsername: "testuser",
+  positionInThread: 2,
+  mediaUrls: ["https://example.com/img.jpg"],
+  tweetedAt: "2026-01-01T12:00:00Z",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("mapTweetThreadSourceToThread", () => {
+  it("maps all fields correctly", () => {
+    const result = mapTweetThreadSourceToThread(mockTweetThreadSource);
+
+    expect(result).toEqual({
+      id: "thread-1",
+      rootTweetId: "tweet-root",
+      authorUsername: "testuser",
+      authorDisplayName: "Test User",
+      title: "Test Thread",
+      tweetCount: 3,
+      fetchedAt: "2026-01-01T00:00:00Z",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("uses createdAt for both fetchedAt and createdAt", () => {
+    const result = mapTweetThreadSourceToThread(mockTweetThreadSource);
+    expect(result.fetchedAt).toBe(result.createdAt);
+  });
+});
+
+describe("mapTweetContentToTweet", () => {
+  it("maps all fields correctly", () => {
+    const result = mapTweetContentToTweet(mockTweetContent, "thread-1");
+
+    expect(result).toEqual({
+      id: "tweet-1",
+      tweetId: "tweet-1",
+      authorUsername: "testuser",
+      // authorDisplayName falls back to username — API does not provide it on tweet content
+      authorDisplayName: "testuser",
+      content: "Hello world",
+      mediaUrls: ["https://example.com/img.jpg"],
+      threadId: "thread-1",
+      positionInThread: 2,
+      tweetedAt: "2026-01-01T12:00:00Z",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("uses id for both id and tweetId", () => {
+    const result = mapTweetContentToTweet(mockTweetContent);
+    expect(result.id).toBe(result.tweetId);
+  });
+
+  it("defaults threadId to empty string when not provided", () => {
+    const result = mapTweetContentToTweet(mockTweetContent);
+    expect(result.threadId).toBe("");
+  });
+
+  it("maps empty mediaUrls", () => {
+    const result = mapTweetContentToTweet({
+      ...mockTweetContent,
+      mediaUrls: [],
+    });
+    expect(result.mediaUrls).toEqual([]);
+  });
+});
+
+describe("mapRelatedItemsToTweets", () => {
+  it("filters out non-tweet items and maps tweet items", () => {
+    const relatedItems = [
+      mockTweetContent,
+      {
+        id: "note-1",
+        contentType: "note" as const,
+        content: "A note",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "tweet-2",
+        contentType: "tweet" as const,
+        content: "Second tweet",
+        authorUsername: "user2",
+        positionInThread: 1,
+        mediaUrls: [],
+        tweetedAt: "2026-01-02T00:00:00Z",
+        createdAt: "2026-01-02T00:00:00Z",
+      },
+    ];
+
+    const result = mapRelatedItemsToTweets(relatedItems, "thread-1");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("tweet-1");
+    expect(result[0].threadId).toBe("thread-1");
+    expect(result[1].id).toBe("tweet-2");
+    expect(result[1].threadId).toBe("thread-1");
+  });
+
+  it("returns empty array when no tweet items", () => {
+    const relatedItems = [
+      {
+        id: "note-1",
+        contentType: "note" as const,
+        content: "A note",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    expect(mapRelatedItemsToTweets(relatedItems)).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(mapRelatedItemsToTweets([])).toEqual([]);
+  });
+});

--- a/src/models/mappers.ts
+++ b/src/models/mappers.ts
@@ -4,9 +4,12 @@ import type {
   BookSource,
   Content,
   NoteContent,
+  TweetContent,
+  TweetThreadSource,
   UrlChunkContent,
   UrlSource,
 } from "./random";
+import type { Tweet, TweetThread } from "./tweet";
 import type { Url, UrlChunk } from "./url";
 
 // Book/Note mappers
@@ -73,3 +76,53 @@ export const mapRelatedItemsToUrlChunks = (
   relatedItems
     .filter((item): item is UrlChunkContent => item.contentType === "url_chunk")
     .map(mapUrlChunkContentToUrlChunk);
+
+// Tweet mappers
+
+/**
+ * Maps a TweetThreadSource (from RandomContent) to a TweetThread domain model
+ */
+export const mapTweetThreadSourceToThread = (
+  source: TweetThreadSource,
+): TweetThread => ({
+  id: source.id,
+  rootTweetId: source.rootTweetId,
+  authorUsername: source.authorUsername,
+  authorDisplayName: source.authorDisplayName,
+  title: source.title,
+  tweetCount: source.tweetCount,
+  // The random API does not provide fetched_at separately; use createdAt for both
+  fetchedAt: source.createdAt,
+  createdAt: source.createdAt,
+});
+
+/**
+ * Maps a TweetContent (from RandomContent) to a Tweet domain model
+ */
+export const mapTweetContentToTweet = (
+  content: TweetContent,
+  threadId = "",
+): Tweet => ({
+  id: content.id,
+  tweetId: content.id,
+  authorUsername: content.authorUsername,
+  // The random API does not include author_display_name on tweet content; fall back to username
+  authorDisplayName: content.authorUsername,
+  content: content.content,
+  mediaUrls: content.mediaUrls,
+  threadId,
+  positionInThread: content.positionInThread,
+  tweetedAt: content.tweetedAt,
+  createdAt: content.createdAt,
+});
+
+/**
+ * Filters and maps Content[] to Tweet[], extracting only tweet items
+ */
+export const mapRelatedItemsToTweets = (
+  relatedItems: Content[],
+  threadId = "",
+): Tweet[] =>
+  relatedItems
+    .filter((item): item is TweetContent => item.contentType === "tweet")
+    .map((item) => mapTweetContentToTweet(item, threadId));

--- a/src/models/random.ts
+++ b/src/models/random.ts
@@ -16,7 +16,18 @@ export interface UrlSource {
   createdAt: string;
 }
 
-export type Source = BookSource | UrlSource;
+export interface TweetThreadSource {
+  id: string;
+  title: string;
+  type: "tweet_thread";
+  authorUsername: string;
+  authorDisplayName: string;
+  rootTweetId: string;
+  tweetCount: number;
+  createdAt: string;
+}
+
+export type Source = BookSource | UrlSource | TweetThreadSource;
 
 export interface NoteContent {
   id: string;
@@ -34,7 +45,18 @@ export interface UrlChunkContent {
   createdAt: string;
 }
 
-export type Content = NoteContent | UrlChunkContent;
+export interface TweetContent {
+  id: string;
+  contentType: "tweet";
+  content: string;
+  authorUsername: string;
+  positionInThread: number;
+  mediaUrls: string[];
+  tweetedAt: string;
+  createdAt: string;
+}
+
+export type Content = NoteContent | UrlChunkContent | TweetContent;
 
 export interface RandomContent {
   source: Source;

--- a/src/pages/Random/RandomPage.test.tsx
+++ b/src/pages/Random/RandomPage.test.tsx
@@ -47,6 +47,42 @@ const mockNoteContent: RandomContent = {
   ],
 };
 
+const mockTweetContent: RandomContent = {
+  source: {
+    id: "thread-1",
+    title: "Test Tweet Thread",
+    type: "tweet_thread",
+    authorUsername: "testuser",
+    authorDisplayName: "Test User",
+    rootTweetId: "tweet-root",
+    tweetCount: 5,
+    createdAt: "2026-01-01T00:00:00Z",
+  },
+  content: {
+    id: "tweet-1",
+    contentType: "tweet",
+    content: "Test tweet content",
+    authorUsername: "testuser",
+    positionInThread: 0,
+    mediaUrls: [],
+    tweetedAt: "2026-01-01T00:00:00Z",
+    createdAt: "2026-01-01T00:00:00Z",
+  },
+  additionalContext: "Additional context for tweet",
+  relatedItems: [
+    {
+      id: "tweet-2",
+      contentType: "tweet",
+      content: "Related tweet content",
+      authorUsername: "testuser",
+      positionInThread: 1,
+      mediaUrls: [],
+      tweetedAt: "2026-01-02T00:00:00Z",
+      createdAt: "2026-01-02T00:00:00Z",
+    },
+  ],
+};
+
 const mockChunkContent: RandomContent = {
   source: {
     id: "url-1",
@@ -151,6 +187,66 @@ describe("RandomPage", () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(
         "/books/book-1/notes/related-note-1",
+      );
+    });
+  });
+
+  describe("when showing tweet content", () => {
+    it("renders TweetDescription on success", () => {
+      mockUseStreamedRandomContent.mockReturnValue({
+        status: "success",
+        data: mockTweetContent,
+      });
+
+      renderWithRouter(<RandomPage />);
+
+      expect(screen.getByText("Test Tweet Thread")).toBeInTheDocument();
+      expect(screen.getByText("Test tweet content")).toBeInTheDocument();
+    });
+
+    it("renders TweetDescription during streaming", () => {
+      mockUseStreamedRandomContent.mockReturnValue({
+        status: "streaming",
+        data: mockTweetContent,
+      });
+
+      renderWithRouter(<RandomPage />);
+
+      expect(screen.getByText("Test Tweet Thread")).toBeInTheDocument();
+      expect(screen.getByText("Test tweet content")).toBeInTheDocument();
+    });
+
+    it("navigates to tweet thread page when thread is clicked", async () => {
+      const user = userEvent.setup();
+      mockUseStreamedRandomContent.mockReturnValue({
+        status: "success",
+        data: mockTweetContent,
+      });
+
+      renderWithRouter(<RandomPage />);
+
+      const threadButton = screen.getByRole("button", {
+        name: /Test Tweet Thread/i,
+      });
+      await user.click(threadButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/tweets/thread-1/");
+    });
+
+    it("navigates to related tweet when clicked", async () => {
+      const user = userEvent.setup();
+      mockUseStreamedRandomContent.mockReturnValue({
+        status: "success",
+        data: mockTweetContent,
+      });
+
+      renderWithRouter(<RandomPage />);
+
+      const relatedTweetButton = screen.getByText("Related tweet content");
+      await user.click(relatedTweetButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "/tweets/thread-1/tweets/tweet-2",
       );
     });
   });

--- a/src/pages/Random/RandomPage.tsx
+++ b/src/pages/Random/RandomPage.tsx
@@ -4,14 +4,19 @@ import {
   mapBookSourceToKindleBook,
   mapNoteContentToKindleNote,
   mapRelatedItemsToNotes,
+  mapRelatedItemsToTweets,
   mapRelatedItemsToUrlChunks,
+  mapTweetContentToTweet,
+  mapTweetThreadSourceToThread,
   mapUrlChunkContentToUrlChunk,
   mapUrlSourceToUrl,
   type NoteContent,
+  type TweetContent,
   type UrlChunkContent,
 } from "src/models";
 import { ChunkDescription } from "../Chunk/ChunkDescription";
 import { NoteDescription } from "../Note/NoteDescription";
+import { TweetDescription } from "../Tweet/TweetDescription";
 import { useStreamedRandomContent } from "./useStreamedRandomContent";
 
 export function RandomPage() {
@@ -27,22 +32,48 @@ export function RandomPage() {
     case "success": {
       const { source, content, additionalContext, relatedItems } = state.data;
 
-      return source.type === "book" ? (
-        <div>
-          <NoteDescription
-            book={mapBookSourceToKindleBook(source)}
-            note={mapNoteContentToKindleNote(content as NoteContent)}
-            relatedNotes={mapRelatedItemsToNotes(relatedItems)}
-            additionalContext={additionalContext}
-            onBookClick={() => {
-              navigate(`/books/${source.id}/`);
-            }}
-            onRelatedNoteClick={(relatedNoteId) => {
-              navigate(`/books/${source.id}/notes/${relatedNoteId}`);
-            }}
-          />
-        </div>
-      ) : (
+      if (source.type === "book") {
+        return (
+          <div>
+            <NoteDescription
+              book={mapBookSourceToKindleBook(source)}
+              note={mapNoteContentToKindleNote(content as NoteContent)}
+              relatedNotes={mapRelatedItemsToNotes(relatedItems)}
+              additionalContext={additionalContext}
+              onBookClick={() => {
+                navigate(`/books/${source.id}/`);
+              }}
+              onRelatedNoteClick={(relatedNoteId) => {
+                navigate(`/books/${source.id}/notes/${relatedNoteId}`);
+              }}
+            />
+          </div>
+        );
+      }
+
+      if (source.type === "tweet_thread") {
+        const thread = mapTweetThreadSourceToThread(source);
+        const tweet = mapTweetContentToTweet(
+          content as TweetContent,
+          source.id,
+        );
+        return (
+          <div>
+            <TweetDescription
+              thread={thread}
+              tweet={tweet}
+              relatedTweets={mapRelatedItemsToTweets(relatedItems, source.id)}
+              additionalContext={additionalContext}
+              onThreadClick={() => navigate(`/tweets/${source.id}/`)}
+              onRelatedTweetClick={(relatedTweetId) =>
+                navigate(`/tweets/${source.id}/tweets/${relatedTweetId}`)
+              }
+            />
+          </div>
+        );
+      }
+
+      return (
         <div>
           <ChunkDescription
             url={mapUrlSourceToUrl(source)}


### PR DESCRIPTION
Extends Source/Content unions with TweetThreadSource and TweetContent.
Adds tweet mappers. Extends randomService to map tweet API responses.
RandomPage renders TweetDescription for tweet_thread sources with
correct navigation to tweet detail pages.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tweet threads and individual tweets now appear in the random content feed — see thread titles, author/display names, tweet text, media, and timestamps; related tweets are shown and clickable to navigate to thread and tweet pages.

* **Tests**
  * Added tests validating mapping, rendering, filtering of related items, and navigation for tweet threads and tweets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->