### PR TITLE
fix: resolve critical bugs in streaming hooks and search encoding

### DIFF
--- a/src/api/searchService.test.ts
+++ b/src/api/searchService.test.ts
@@ -64,7 +64,7 @@ describe("SearchService", () => {
 
       const result = await searchService.search("test query");
 
-      expect(httpClient.request).toHaveBeenCalledWith("/search?q=test query");
+      expect(httpClient.request).toHaveBeenCalledWith("/search?q=test%20query");
       expect(result.data).toEqual({
         q: "test query",
         books: [

--- a/src/api/searchService.ts
+++ b/src/api/searchService.ts
@@ -25,7 +25,7 @@ const mapSearchResult = (apiResult: SearchResultApiResponse): SearchResult => ({
 });
 
 const ENDPOINTS = {
-  SEARCH: (query: string) => `/search?q=${query}`,
+  SEARCH: (query: string) => `/search?q=${encodeURIComponent(query)}`,
 } as const;
 
 export class SearchService {

--- a/src/pages/Chunk/useStreamedDetailedChunk.ts
+++ b/src/pages/Chunk/useStreamedDetailedChunk.ts
@@ -28,9 +28,12 @@ export function useStreamedDetailedChunk(
       onContextChunk: (content: string) => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot process context chunk in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot process context chunk in ${prev.status} state`,
+              ),
+            };
           }
           const { relatedChunks, chunk, url, additionalContext } = prev.data;
           const updatedAdditionalContext = `${additionalContext}${content}`;
@@ -48,9 +51,12 @@ export function useStreamedDetailedChunk(
       onComplete: () => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot complete streaming in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot complete streaming in ${prev.status} state`,
+              ),
+            };
           }
           return {
             status: "success",

--- a/src/pages/Note/useStreamedDetailedNote.ts
+++ b/src/pages/Note/useStreamedDetailedNote.ts
@@ -17,6 +17,7 @@ export function useStreamedDetailedNote(
   });
 
   useEffect(() => {
+    setState({ status: "loading" });
     const handlers = {
       onMetadata: (note: KindleDetailedNote) => {
         setState({
@@ -27,9 +28,12 @@ export function useStreamedDetailedNote(
       onContextChunk: (content: string) => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot process context chunk in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot process context chunk in ${prev.status} state`,
+              ),
+            };
           }
           const { relatedNotes, note, book, additionalContext } = prev.note;
           const updatedAdditionalContext = `${additionalContext}${content}`;
@@ -47,9 +51,12 @@ export function useStreamedDetailedNote(
       onComplete: () => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot complete streaming in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot complete streaming in ${prev.status} state`,
+              ),
+            };
           }
           return {
             status: "success",

--- a/src/pages/Random/RandomPage.tsx
+++ b/src/pages/Random/RandomPage.tsx
@@ -10,9 +10,6 @@ import {
   mapTweetThreadSourceToThread,
   mapUrlChunkContentToUrlChunk,
   mapUrlSourceToUrl,
-  type NoteContent,
-  type TweetContent,
-  type UrlChunkContent,
 } from "src/models";
 import { ChunkDescription } from "../Chunk/ChunkDescription";
 import { NoteDescription } from "../Note/NoteDescription";
@@ -33,11 +30,16 @@ export function RandomPage() {
       const { source, content, additionalContext, relatedItems } = state.data;
 
       if (source.type === "book") {
+        if (content.contentType !== "note") {
+          throw new Error(
+            `Expected note content for book source, got ${content.contentType}`,
+          );
+        }
         return (
           <div>
             <NoteDescription
               book={mapBookSourceToKindleBook(source)}
-              note={mapNoteContentToKindleNote(content as NoteContent)}
+              note={mapNoteContentToKindleNote(content)}
               relatedNotes={mapRelatedItemsToNotes(relatedItems)}
               additionalContext={additionalContext}
               onBookClick={() => {
@@ -52,8 +54,13 @@ export function RandomPage() {
       }
 
       if (source.type === "tweet_thread") {
+        if (content.contentType !== "tweet") {
+          throw new Error(
+            `Expected tweet content for tweet_thread source, got ${content.contentType}`,
+          );
+        }
         const thread = mapTweetThreadSourceToThread(source);
-        const tweet = mapTweetContentToTweet(content as TweetContent);
+        const tweet = mapTweetContentToTweet(content);
         return (
           <div>
             <TweetDescription
@@ -70,11 +77,16 @@ export function RandomPage() {
         );
       }
 
+      if (content.contentType !== "url_chunk") {
+        throw new Error(
+          `Expected url_chunk content for url source, got ${content.contentType}`,
+        );
+      }
       return (
         <div>
           <ChunkDescription
             url={mapUrlSourceToUrl(source)}
-            chunk={mapUrlChunkContentToUrlChunk(content as UrlChunkContent)}
+            chunk={mapUrlChunkContentToUrlChunk(content)}
             relatedChunks={mapRelatedItemsToUrlChunks(relatedItems)}
             additionalContext={additionalContext}
             onUrlClick={() => {

--- a/src/pages/Random/useStreamedRandomContent.ts
+++ b/src/pages/Random/useStreamedRandomContent.ts
@@ -24,9 +24,12 @@ export function useStreamedRandomContent(): StreamState {
       onContextChunk: (content: string) => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot process context chunk in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot process context chunk in ${prev.status} state`,
+              ),
+            };
           }
           return {
             ...prev,
@@ -40,9 +43,12 @@ export function useStreamedRandomContent(): StreamState {
       onComplete: () => {
         setState((prev) => {
           if (prev.status !== "streaming") {
-            throw new Error(
-              `Cannot complete streaming in ${prev.status} state`,
-            );
+            return {
+              status: "error",
+              error: new Error(
+                `Cannot complete streaming in ${prev.status} state`,
+              ),
+            };
           }
           return {
             status: "success",


### PR DESCRIPTION
- Fix unsafe `throw` inside setState updaters in all four streaming
  hooks (useStreamedDetailedNote, useStreamedDetailedChunk,
  useStreamedRandomContent) — throwing inside a React state updater is
  not caught by error boundaries; return error state instead
- Add missing setState({ status: "loading" }) reset at effect start in
  useStreamedDetailedNote, matching the other streaming hooks and
  preventing stale content from showing when navigating between notes
- Replace unsafe `as` casts in RandomPage with explicit contentType
  guards, eliminating silent mismatches if source/content types diverge
- URL-encode search query in searchService to fix searches containing
  spaces, &, + or non-ASCII characters

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search queries with spaces and special characters are now properly URL-encoded when sent, improving search reliability across edge cases.
  * Streaming operations now set a clear error state instead of throwing runtime exceptions when callbacks occur out of sequence, preventing crashes and improving UI stability.
  * Added runtime validation of content types to prevent misprocessing and ensure only expected content shapes are rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->