### PR TITLE
Persist home tab selection in URL

### DIFF
--- a/src/pages/Home/HomePage.test.tsx
+++ b/src/pages/Home/HomePage.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { booksService, tweetService, urlService } from "src/api";
 import type { KindleBook, TweetThread, Url } from "src/models";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,7 +34,17 @@ vi.mock("react-router", async () => {
   };
 });
 
-async function renderWithProviders(ui: React.ReactElement) {
+function LocationDisplay() {
+  const location = useLocation();
+
+  return <div data-testid="location-display">{location.search}</div>;
+}
+
+async function renderWithProviders(
+  ui: React.ReactElement,
+  initialEntries: string[] = ["/"],
+  waitForText = "The Great Gatsby",
+) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -44,14 +54,17 @@ async function renderWithProviders(ui: React.ReactElement) {
   });
 
   const result = render(
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider client={queryClient}>
+        <LocationDisplay />
+        {ui}
+      </QueryClientProvider>
     </MemoryRouter>,
   );
 
-  // Wait for initial data to load (Books tab is default)
+  // Wait for initial data to load
   await waitFor(() => {
-    expect(screen.getByText("The Great Gatsby")).toBeInTheDocument();
+    expect(screen.getByText(waitForText)).toBeInTheDocument();
   });
 
   return result;
@@ -154,8 +167,10 @@ describe("HomePage", () => {
       expect(screen.queryByText("Example Article 2")).not.toBeInTheDocument();
     });
 
-    it("switches to URLs tab when clicked", async () => {
+    it("switches to URLs tab when clicked and updates the URL", async () => {
       await renderWithProviders(<HomePage />);
+
+      expect(screen.getByTestId("location-display")).toHaveTextContent("");
 
       // Click URLs tab
       const urlsTab = screen.getByRole("tab", { name: /^URLs$/i });
@@ -168,6 +183,13 @@ describe("HomePage", () => {
       // Books should not be visible
       expect(screen.queryByText("The Great Gatsby")).not.toBeInTheDocument();
       expect(screen.queryByText("1984")).not.toBeInTheDocument();
+
+      // URL should reflect the selected tab
+      await waitFor(() => {
+        expect(screen.getByTestId("location-display")).toHaveTextContent(
+          "?tab=urls",
+        );
+      });
 
       // Tab should be marked as active
       expect(urlsTab).toHaveAttribute("aria-selected", "true");
@@ -213,6 +235,9 @@ describe("HomePage", () => {
 
       const urlsTab = screen.getByRole("tab", { name: /^URLs$/i });
       expect(urlsTab).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "?tab=urls",
+      );
     });
 
     it("switches tabs with arrow keys from URLs tab", async () => {
@@ -232,10 +257,44 @@ describe("HomePage", () => {
 
       const booksTab = screen.getByRole("tab", { name: /^Books$/i });
       expect(booksTab).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "?tab=books",
+      );
     });
   });
 
   describe("Accessibility", () => {
+    it("loads URLs tab from the query parameter", async () => {
+      await renderWithProviders(
+        <HomePage />,
+        ["/?tab=urls"],
+        "Example Article 1",
+      );
+
+      expect(screen.getByText("Example Article 1")).toBeInTheDocument();
+      expect(screen.getByText("Example Article 2")).toBeInTheDocument();
+      expect(screen.queryByText("The Great Gatsby")).not.toBeInTheDocument();
+
+      const urlsTab = screen.getByRole("tab", { name: /^URLs$/i });
+      expect(urlsTab).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "?tab=urls",
+      );
+    });
+
+    it("falls back to Books for invalid query parameters", async () => {
+      await renderWithProviders(<HomePage />, ["/?tab=invalid"]);
+
+      expect(screen.getByText("The Great Gatsby")).toBeInTheDocument();
+      expect(screen.getByText("1984")).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("location-display")).toHaveTextContent(
+          "?tab=books",
+        );
+      });
+    });
+
     it("has proper ARIA attributes for tabs", async () => {
       await renderWithProviders(<HomePage />);
 

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -1,5 +1,5 @@
-import { useId, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useEffect, useId, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 import {
   booksService,
   tweetService,
@@ -12,9 +12,15 @@ import { UrlList } from "./UrlList";
 
 type Tab = "books" | "urls" | "tweets";
 
+function isTab(value: string | null): value is Tab {
+  return value === "books" || value === "urls" || value === "tweets";
+}
+
 export function HomePage() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<Tab>("books");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const activeTab: Tab = isTab(tabParam) ? tabParam : "books";
   const booksTabId = useId();
   const urlsTabId = useId();
   const tweetsTabId = useId();
@@ -25,6 +31,15 @@ export function HomePage() {
   const urlsTabRef = useRef<HTMLButtonElement>(null);
   const tweetsTabRef = useRef<HTMLButtonElement>(null);
 
+  useEffect(() => {
+    // Only normalize invalid tab values; omit the param entirely when no tab is set.
+    if (tabParam !== null && !isTab(tabParam)) {
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.set("tab", "books");
+      setSearchParams(nextSearchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, tabParam]);
+
   const booksResult = useApiSuspenseQuery(["books"], () =>
     booksService.getBooks(),
   );
@@ -32,6 +47,20 @@ export function HomePage() {
   const tweetsResult = useApiSuspenseQuery(["tweets"], () =>
     tweetService.getTweets(),
   );
+
+  const updateTab = (tab: Tab) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set("tab", tab);
+    setSearchParams(nextSearchParams);
+
+    if (tab === "books") {
+      booksTabRef.current?.focus();
+    } else if (tab === "urls") {
+      urlsTabRef.current?.focus();
+    } else {
+      tweetsTabRef.current?.focus();
+    }
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
@@ -41,14 +70,7 @@ export function HomePage() {
       const direction = e.key === "ArrowRight" ? 1 : -1;
       const newTab =
         tabs[(currentIndex + direction + tabs.length) % tabs.length];
-      setActiveTab(newTab);
-      if (newTab === "books") {
-        booksTabRef.current?.focus();
-      } else if (newTab === "urls") {
-        urlsTabRef.current?.focus();
-      } else {
-        tweetsTabRef.current?.focus();
-      }
+      updateTab(newTab);
     }
   };
 
@@ -75,7 +97,7 @@ export function HomePage() {
           aria-controls={booksPanelId}
           id={booksTabId}
           tabIndex={activeTab === "books" ? 0 : -1}
-          onClick={() => setActiveTab("books")}
+          onClick={() => updateTab("books")}
           onKeyDown={handleKeyDown}
           className={getTabClassName(activeTab === "books")}
         >
@@ -89,7 +111,7 @@ export function HomePage() {
           aria-controls={urlsPanelId}
           id={urlsTabId}
           tabIndex={activeTab === "urls" ? 0 : -1}
-          onClick={() => setActiveTab("urls")}
+          onClick={() => updateTab("urls")}
           onKeyDown={handleKeyDown}
           className={getTabClassName(activeTab === "urls")}
         >
@@ -103,7 +125,7 @@ export function HomePage() {
           aria-controls={tweetsPanelId}
           id={tweetsTabId}
           tabIndex={activeTab === "tweets" ? 0 : -1}
-          onClick={() => setActiveTab("tweets")}
+          onClick={() => updateTab("tweets")}
           onKeyDown={handleKeyDown}
           className={getTabClassName(activeTab === "tweets")}
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Tab navigation now syncs with the browser URL, enabling back/forward navigation and shareable tab links.
  * Invalid tab parameters automatically default to the books tab for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->