### PR TITLE
Match upload page mode toggle buttons to home page tab styling

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,67 @@
+import { useRef } from "react";
+
+export type TabItem<T extends string = string> = {
+  id: T;
+  label: string;
+  buttonId?: string;
+  panelId?: string;
+};
+
+interface TabBarProps<T extends string = string> {
+  tabs: TabItem<T>[];
+  activeTab: T;
+  onChange: (tab: T) => void;
+}
+
+const getTabClassName = (isActive: boolean) => {
+  const base =
+    "px-6 py-3 text-sm font-medium rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900";
+  const active =
+    "text-white bg-blue-600/20 border border-blue-500 hover:border-blue-400";
+  const inactive =
+    "text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-500";
+  return `${base} ${isActive ? active : inactive}`;
+};
+
+export function TabBar<T extends string>({
+  tabs,
+  activeTab,
+  onChange,
+}: TabBarProps<T>) {
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const currentIndex = tabs.findIndex((t) => t.id === activeTab);
+    const direction = e.key === "ArrowRight" ? 1 : -1;
+    const nextTab = tabs[(currentIndex + direction + tabs.length) % tabs.length];
+    onChange(nextTab.id);
+    buttonRefs.current.get(nextTab.id)?.focus();
+  };
+
+  return (
+    <div role="tablist" className="flex gap-4 mb-6">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          ref={(el) => {
+            if (el) buttonRefs.current.set(tab.id, el);
+            else buttonRefs.current.delete(tab.id);
+          }}
+          type="button"
+          role="tab"
+          id={tab.buttonId}
+          aria-selected={tab.id === activeTab}
+          aria-controls={tab.panelId}
+          tabIndex={tab.id === activeTab ? 0 : -1}
+          onClick={() => onChange(tab.id)}
+          onKeyDown={handleKeyDown}
+          className={getTabClassName(tab.id === activeTab)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -35,7 +35,8 @@ export function TabBar<T extends string>({
     e.preventDefault();
     const currentIndex = tabs.findIndex((t) => t.id === activeTab);
     const direction = e.key === "ArrowRight" ? 1 : -1;
-    const nextTab = tabs[(currentIndex + direction + tabs.length) % tabs.length];
+    const nextTab =
+      tabs[(currentIndex + direction + tabs.length) % tabs.length];
     onChange(nextTab.id);
     buttonRefs.current.get(nextTab.id)?.focus();
   };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,7 @@ export { FileDropZone } from "./FileDropZone";
 export { Footer } from "./Footer";
 export { Header } from "./Header";
 export { LoadingIndicator } from "./LoadingIndicator";
-export { TabBar } from "./TabBar";
 export type { TabItem } from "./TabBar";
+export { TabBar } from "./TabBar";
 export { UploadControl } from "./UploadControl";
 export { UrlInputZone } from "./UrlInputZone";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,5 +5,7 @@ export { FileDropZone } from "./FileDropZone";
 export { Footer } from "./Footer";
 export { Header } from "./Header";
 export { LoadingIndicator } from "./LoadingIndicator";
+export { TabBar } from "./TabBar";
+export type { TabItem } from "./TabBar";
 export { UploadControl } from "./UploadControl";
 export { UrlInputZone } from "./UrlInputZone";

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -52,9 +52,24 @@ export function HomePage() {
   };
 
   const tabs = [
-    { id: "books" as const, label: "Books", buttonId: booksTabId, panelId: booksPanelId },
-    { id: "urls" as const, label: "URLs", buttonId: urlsTabId, panelId: urlsPanelId },
-    { id: "tweets" as const, label: "Tweets", buttonId: tweetsTabId, panelId: tweetsPanelId },
+    {
+      id: "books" as const,
+      label: "Books",
+      buttonId: booksTabId,
+      panelId: booksPanelId,
+    },
+    {
+      id: "urls" as const,
+      label: "URLs",
+      buttonId: urlsTabId,
+      panelId: urlsPanelId,
+    },
+    {
+      id: "tweets" as const,
+      label: "Tweets",
+      buttonId: tweetsTabId,
+      panelId: tweetsPanelId,
+    },
   ];
 
   return (

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import {
   booksService,
@@ -6,6 +6,7 @@ import {
   urlService,
   useApiSuspenseQuery,
 } from "src/api";
+import { TabBar } from "src/components";
 import { BookList } from "./BookList";
 import { TweetList } from "./TweetList";
 import { UrlList } from "./UrlList";
@@ -27,12 +28,8 @@ export function HomePage() {
   const booksPanelId = useId();
   const urlsPanelId = useId();
   const tweetsPanelId = useId();
-  const booksTabRef = useRef<HTMLButtonElement>(null);
-  const urlsTabRef = useRef<HTMLButtonElement>(null);
-  const tweetsTabRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    // Only normalize invalid tab values; omit the param entirely when no tab is set.
     if (tabParam !== null && !isTab(tabParam)) {
       const nextSearchParams = new URLSearchParams(searchParams);
       nextSearchParams.set("tab", "books");
@@ -52,88 +49,18 @@ export function HomePage() {
     const nextSearchParams = new URLSearchParams(searchParams);
     nextSearchParams.set("tab", tab);
     setSearchParams(nextSearchParams);
-
-    if (tab === "books") {
-      booksTabRef.current?.focus();
-    } else if (tab === "urls") {
-      urlsTabRef.current?.focus();
-    } else {
-      tweetsTabRef.current?.focus();
-    }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
-      e.preventDefault();
-      const tabs: Tab[] = ["books", "urls", "tweets"];
-      const currentIndex = tabs.indexOf(activeTab);
-      const direction = e.key === "ArrowRight" ? 1 : -1;
-      const newTab =
-        tabs[(currentIndex + direction + tabs.length) % tabs.length];
-      updateTab(newTab);
-    }
-  };
-
-  const getTabClassName = (isActive: boolean) => {
-    const baseClasses =
-      "px-6 py-3 text-sm font-medium rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900";
-    const activeClasses =
-      "text-white bg-blue-600/20 border border-blue-500 hover:border-blue-400";
-    const inactiveClasses =
-      "text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-500";
-
-    return `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`;
-  };
+  const tabs = [
+    { id: "books" as const, label: "Books", buttonId: booksTabId, panelId: booksPanelId },
+    { id: "urls" as const, label: "URLs", buttonId: urlsTabId, panelId: urlsPanelId },
+    { id: "tweets" as const, label: "Tweets", buttonId: tweetsTabId, panelId: tweetsPanelId },
+  ];
 
   return (
     <div className="space-y-6">
-      {/* Tab Navigation */}
-      <div role="tablist" className="flex gap-4 mb-6">
-        <button
-          ref={booksTabRef}
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "books"}
-          aria-controls={booksPanelId}
-          id={booksTabId}
-          tabIndex={activeTab === "books" ? 0 : -1}
-          onClick={() => updateTab("books")}
-          onKeyDown={handleKeyDown}
-          className={getTabClassName(activeTab === "books")}
-        >
-          Books
-        </button>
-        <button
-          ref={urlsTabRef}
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "urls"}
-          aria-controls={urlsPanelId}
-          id={urlsTabId}
-          tabIndex={activeTab === "urls" ? 0 : -1}
-          onClick={() => updateTab("urls")}
-          onKeyDown={handleKeyDown}
-          className={getTabClassName(activeTab === "urls")}
-        >
-          URLs
-        </button>
-        <button
-          ref={tweetsTabRef}
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "tweets"}
-          aria-controls={tweetsPanelId}
-          id={tweetsTabId}
-          tabIndex={activeTab === "tweets" ? 0 : -1}
-          onClick={() => updateTab("tweets")}
-          onKeyDown={handleKeyDown}
-          className={getTabClassName(activeTab === "tweets")}
-        >
-          Tweets
-        </button>
-      </div>
+      <TabBar tabs={tabs} activeTab={activeTab} onChange={updateTab} />
 
-      {/* Tab Panels */}
       {activeTab === "books" && (
         <section role="tabpanel" id={booksPanelId} aria-labelledby={booksTabId}>
           <BookList

--- a/src/pages/Upload/UploadPage.test.tsx
+++ b/src/pages/Upload/UploadPage.test.tsx
@@ -222,9 +222,7 @@ describe("UploadPage", () => {
       expect(
         screen.getByRole("tab", { name: /url upload/i }),
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("tab", { name: /^tweet$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /^tweet$/i })).toBeInTheDocument();
     });
 
     it("switches from file mode to url mode", async () => {

--- a/src/pages/Upload/UploadPage.test.tsx
+++ b/src/pages/Upload/UploadPage.test.tsx
@@ -68,17 +68,17 @@ function createTestFile(name = "test.txt", content = "test content") {
 }
 
 async function switchToUrlMode(user: ReturnType<typeof userEvent.setup>) {
-  const urlButton = screen.getByRole("button", { name: /url upload/i });
+  const urlButton = screen.getByRole("tab", { name: /url upload/i });
   await user.click(urlButton);
 }
 
 async function switchToFileMode(user: ReturnType<typeof userEvent.setup>) {
-  const fileButton = screen.getByRole("button", { name: /file upload/i });
+  const fileButton = screen.getByRole("tab", { name: /file upload/i });
   await user.click(fileButton);
 }
 
 async function switchToTweetMode(user: ReturnType<typeof userEvent.setup>) {
-  const tweetButton = screen.getByRole("button", { name: /^tweet$/i });
+  const tweetButton = screen.getByRole("tab", { name: /^tweet$/i });
   await user.click(tweetButton);
 }
 
@@ -217,13 +217,13 @@ describe("UploadPage", () => {
   describe("Mode toggle", () => {
     it("renders file, url, and tweet mode buttons", () => {
       expect(
-        screen.getByRole("button", { name: /file upload/i }),
+        screen.getByRole("tab", { name: /file upload/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /url upload/i }),
+        screen.getByRole("tab", { name: /url upload/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /^tweet$/i }),
+        screen.getByRole("tab", { name: /^tweet$/i }),
       ).toBeInTheDocument();
     });
 

--- a/src/pages/Upload/UploadPage.tsx
+++ b/src/pages/Upload/UploadPage.tsx
@@ -8,7 +8,12 @@ import {
   urlService,
   useApiMutation,
 } from "src/api";
-import { FileDropZone, TabBar, UploadControl, UrlInputZone } from "src/components";
+import {
+  FileDropZone,
+  TabBar,
+  UploadControl,
+  UrlInputZone,
+} from "src/components";
 import { validateTweetUrl, validateUrl } from "src/utils/validation";
 
 type UploadMode = "file" | "url" | "tweet";

--- a/src/pages/Upload/UploadPage.tsx
+++ b/src/pages/Upload/UploadPage.tsx
@@ -101,26 +101,32 @@ export function UploadPage() {
     handleUpload();
   };
 
+  const getModeButtonClassName = (isActive: boolean) => {
+    const baseClasses =
+      "px-6 py-3 text-sm font-medium rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900";
+    const activeClasses =
+      "text-white bg-blue-600/20 border border-blue-500 hover:border-blue-400";
+    const inactiveClasses =
+      "text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-500";
+    return `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`;
+  };
+
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6">
+    <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">
         Upload Notes
       </h1>
 
       <form onSubmit={handleSubmit}>
         {/* Mode Toggle */}
-        <fieldset className="mb-6 border-0 p-0">
+        <fieldset className="border-0 p-0">
           <legend className="sr-only">Upload Mode</legend>
-          <div className="inline-flex gap-2 rounded-lg border border-gray-300 p-1 bg-white">
+          <div className="flex gap-4 mb-6">
             <button
               type="button"
               onClick={() => handleModeChange("file")}
               aria-pressed={uploadMode === "file"}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                uploadMode === "file"
-                  ? "bg-blue-600 text-white shadow-sm ring-2 ring-blue-600 ring-offset-1"
-                  : "text-gray-700 hover:bg-gray-100"
-              }`}
+              className={getModeButtonClassName(uploadMode === "file")}
             >
               File Upload
             </button>
@@ -128,11 +134,7 @@ export function UploadPage() {
               type="button"
               onClick={() => handleModeChange("url")}
               aria-pressed={uploadMode === "url"}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                uploadMode === "url"
-                  ? "bg-blue-600 text-white shadow-sm ring-2 ring-blue-600 ring-offset-1"
-                  : "text-gray-700 hover:bg-gray-100"
-              }`}
+              className={getModeButtonClassName(uploadMode === "url")}
             >
               URL Upload
             </button>
@@ -140,11 +142,7 @@ export function UploadPage() {
               type="button"
               onClick={() => handleModeChange("tweet")}
               aria-pressed={uploadMode === "tweet"}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                uploadMode === "tweet"
-                  ? "bg-blue-600 text-white shadow-sm ring-2 ring-blue-600 ring-offset-1"
-                  : "text-gray-700 hover:bg-gray-100"
-              }`}
+              className={getModeButtonClassName(uploadMode === "tweet")}
             >
               Tweet
             </button>

--- a/src/pages/Upload/UploadPage.tsx
+++ b/src/pages/Upload/UploadPage.tsx
@@ -8,10 +8,16 @@ import {
   urlService,
   useApiMutation,
 } from "src/api";
-import { FileDropZone, UploadControl, UrlInputZone } from "src/components";
+import { FileDropZone, TabBar, UploadControl, UrlInputZone } from "src/components";
 import { validateTweetUrl, validateUrl } from "src/utils/validation";
 
 type UploadMode = "file" | "url" | "tweet";
+
+const UPLOAD_TABS = [
+  { id: "file" as const, label: "File Upload" },
+  { id: "url" as const, label: "URL Upload" },
+  { id: "tweet" as const, label: "Tweet" },
+];
 
 export function UploadPage() {
   const navigate = useNavigate();
@@ -56,33 +62,26 @@ export function UploadPage() {
     ["tweets"],
   );
 
-  const handleFilesSelected = (files: File[]) => {
-    setSelectedFile(files[0]);
-  };
-
   const handleClear = () => {
     setSelectedFile(null);
     setUrlInput("");
     setTweetInput("");
   };
 
+  const handleModeChange = (mode: UploadMode) => {
+    setUploadMode(mode);
+    handleClear();
+  };
+
   const handleUpload = () => {
     if (uploadMode === "file") {
-      if (selectedFile === null) {
-        return;
-      }
+      if (selectedFile === null) return;
       fileMutation.mutate(selectedFile);
     } else if (uploadMode === "url") {
       urlMutation.mutate(urlInput);
     } else {
       tweetMutation.mutate(tweetInput);
     }
-  };
-
-  const handleModeChange = (mode: UploadMode) => {
-    setUploadMode(mode);
-    // Clear state when switching modes
-    handleClear();
   };
 
   const hasContent: Record<UploadMode, boolean> = {
@@ -101,16 +100,6 @@ export function UploadPage() {
     handleUpload();
   };
 
-  const getModeButtonClassName = (isActive: boolean) => {
-    const baseClasses =
-      "px-6 py-3 text-sm font-medium rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900";
-    const activeClasses =
-      "text-white bg-blue-600/20 border border-blue-500 hover:border-blue-400";
-    const inactiveClasses =
-      "text-zinc-400 hover:text-zinc-200 border border-zinc-700 hover:border-zinc-500";
-    return `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`;
-  };
-
   return (
     <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">
@@ -118,41 +107,15 @@ export function UploadPage() {
       </h1>
 
       <form onSubmit={handleSubmit}>
-        {/* Mode Toggle */}
-        <fieldset className="border-0 p-0">
-          <legend className="sr-only">Upload Mode</legend>
-          <div className="flex gap-4 mb-6">
-            <button
-              type="button"
-              onClick={() => handleModeChange("file")}
-              aria-pressed={uploadMode === "file"}
-              className={getModeButtonClassName(uploadMode === "file")}
-            >
-              File Upload
-            </button>
-            <button
-              type="button"
-              onClick={() => handleModeChange("url")}
-              aria-pressed={uploadMode === "url"}
-              className={getModeButtonClassName(uploadMode === "url")}
-            >
-              URL Upload
-            </button>
-            <button
-              type="button"
-              onClick={() => handleModeChange("tweet")}
-              aria-pressed={uploadMode === "tweet"}
-              className={getModeButtonClassName(uploadMode === "tweet")}
-            >
-              Tweet
-            </button>
-          </div>
-        </fieldset>
+        <TabBar
+          tabs={UPLOAD_TABS}
+          activeTab={uploadMode}
+          onChange={handleModeChange}
+        />
 
-        {/* Upload Area */}
         {uploadMode === "file" ? (
           <FileDropZone
-            onFilesSelected={handleFilesSelected}
+            onFilesSelected={(files) => setSelectedFile(files[0])}
             selectedFiles={selectedFile ? [selectedFile] : []}
             acceptedTypes={["txt", "html"]}
             maxFiles={1}
@@ -169,7 +132,6 @@ export function UploadPage() {
           />
         )}
 
-        {/* Upload Control */}
         <UploadControl
           hasContent={hasContent[uploadMode]}
           onClear={handleClear}


### PR DESCRIPTION
Update padding, margins, and button styles on UploadPage to match
the tab navigation style used on HomePage — bordered buttons with
zinc dark-theme colors, larger padding (px-6 py-3), and consistent
spacing (gap-4 mb-6).

https://claude.ai/code/session_01Y2cqHXkLHJi3fQvHsTmbZr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual styling and layout of the Upload page's mode toggle interface. The File, URL, and Tweet mode buttons now feature improved styling consistency, refined spacing, and updated focus-ring behavior for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->