### PR TITLE
Remove "Upload" from tab button labels on upload page

### DIFF
--- a/src/pages/Upload/UploadPage.test.tsx
+++ b/src/pages/Upload/UploadPage.test.tsx
@@ -68,12 +68,12 @@ function createTestFile(name = "test.txt", content = "test content") {
 }
 
 async function switchToUrlMode(user: ReturnType<typeof userEvent.setup>) {
-  const urlButton = screen.getByRole("tab", { name: /url upload/i });
+  const urlButton = screen.getByRole("tab", { name: /^url$/i });
   await user.click(urlButton);
 }
 
 async function switchToFileMode(user: ReturnType<typeof userEvent.setup>) {
-  const fileButton = screen.getByRole("tab", { name: /file upload/i });
+  const fileButton = screen.getByRole("tab", { name: /^file$/i });
   await user.click(fileButton);
 }
 
@@ -217,10 +217,10 @@ describe("UploadPage", () => {
   describe("Mode toggle", () => {
     it("renders file, url, and tweet mode buttons", () => {
       expect(
-        screen.getByRole("tab", { name: /file upload/i }),
+        screen.getByRole("tab", { name: /^file$/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("tab", { name: /url upload/i }),
+        screen.getByRole("tab", { name: /^url$/i }),
       ).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /^tweet$/i })).toBeInTheDocument();
     });

--- a/src/pages/Upload/UploadPage.test.tsx
+++ b/src/pages/Upload/UploadPage.test.tsx
@@ -216,12 +216,8 @@ describe("UploadPage", () => {
 
   describe("Mode toggle", () => {
     it("renders file, url, and tweet mode buttons", () => {
-      expect(
-        screen.getByRole("tab", { name: /^file$/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("tab", { name: /^url$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /^file$/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /^url$/i })).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /^tweet$/i })).toBeInTheDocument();
     });
 

--- a/src/pages/Upload/UploadPage.tsx
+++ b/src/pages/Upload/UploadPage.tsx
@@ -19,8 +19,8 @@ import { validateTweetUrl, validateUrl } from "src/utils/validation";
 type UploadMode = "file" | "url" | "tweet";
 
 const UPLOAD_TABS = [
-  { id: "file" as const, label: "File Upload" },
-  { id: "url" as const, label: "URL Upload" },
+  { id: "file" as const, label: "File" },
+  { id: "url" as const, label: "URL" },
   { id: "tweet" as const, label: "Tweet" },
 ];
 


### PR DESCRIPTION
Simplifies "File Upload" → "File" and "URL Upload" → "URL" for cleaner tab labels.

https://claude.ai/code/session_01Q9kNDsBruxKq7waxhfZdio